### PR TITLE
Disable Package Creation on Init

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "lambda_function" {
   tags                              = local.tags
   cloudwatch_logs_retention_in_days = var.cwl_retention_in_days
   cloudwatch_logs_tags              = local.cwl_tags
+  create_package                    = false # disable package creation on init. to bypass python preparation step on RunAtlantis
 
   source_path = var.source_path
 }


### PR DESCRIPTION
## Description
There is an error during the migration to RunAltantis. Where the lambda function module need to create package locally using local python executable (in this case RunAtlantis). As we don't have or probably don't need python executable on RunAltantis. I am raising a pull-request to disable it by default. (By default It turned on by the module).